### PR TITLE
Fix smart quotes in planet descriptions

### DIFF
--- a/GameData/OPM/Localization/en-us.cfg
+++ b/GameData/OPM/Localization/en-us.cfg
@@ -40,7 +40,7 @@ Localization
 		#LOC_OPM_Planets_Biome_EquatorialZonesDisplayName = Equatorial Zones
 		//Plock
 		#LOC_OPM_Plock_displayName = Plock^N
-		#LOC_OPM_Planets_Plock_description = There’s been a considerable amount of controversy  concerning the status of Plock as being a proper planet or just a lump of ice going around the Sun. The debate is still ongoing, as most academic summits held to address the issue have devolved into, on good days, petty name calling, and on worse ones, all-out brawls.
+		#LOC_OPM_Planets_Plock_description = There's been a considerable amount of controversy  concerning the status of Plock as being a proper planet or just a lump of ice going around the Sun. The debate is still ongoing, as most academic summits held to address the issue have devolved into, on good days, petty name calling, and on worse ones, all-out brawls.
 		#LOC_OPM_Planets_Biome_AyarzaHillsDisplayName = Ayarza Hills
 		#LOC_OPM_Planets_Biome_ChulakHillsDisplayName = Chulak Hills
 		#LOC_OPM_Planets_Biome_RosasHillsDisplayName = Rosas Hills
@@ -214,9 +214,9 @@ Localization
 		#LOC_OPM_ScienceDefs_SlateSrfLandedMuilHills = The soil here is surprisingly soft, like Play-Koh.
 		#LOC_OPM_ScienceDefs_SlateSrfLandedDagorladRegion = Years of training has brought Kerbalkind here, to find this handful of dust! You hope you won't be fired for that.
 		#LOC_OPM_ScienceDefs_SlateSrfLandedPoles = You take a sample of the "ice". Its texture is brittle with watery attributes. There might have been water here.
-		#LOC_OPM_ScienceDefs_SlateSrfLandedSouthernIslands = The soil reminds you of the sand on Kerbin’s beaches, but it’s less dense and darker in color.
-		#LOC_OPM_ScienceDefs_SlateSrfLandedNorthernIslands = The soil reminds you of the sand on Kerbin’s beaches, but it’s less dense and darker in color.
-		#LOC_OPM_ScienceDefs_SlateSrfLandedKowganArchipelago = The soil reminds you of the sand on Kerbin’s beaches, but it’s less dense and darker in color.
+		#LOC_OPM_ScienceDefs_SlateSrfLandedSouthernIslands = The soil reminds you of the sand on Kerbin's beaches, but it's less dense and darker in color.
+		#LOC_OPM_ScienceDefs_SlateSrfLandedNorthernIslands = The soil reminds you of the sand on Kerbin's beaches, but it's less dense and darker in color.
+		#LOC_OPM_ScienceDefs_SlateSrfLandedKowganArchipelago = The soil reminds you of the sand on Kerbin's beaches, but it's less dense and darker in color.
 		#LOC_OPM_ScienceDefs_SlateSrfLandedTygooValley = Years of training has brought Kerbalkind here, to find this handful of dust! You hope you won't be fired for that.
 		#LOC_OPM_ScienceDefs_SlateSrfLandedOrodruinChaos = The rocks here are a mixture of sand and gravel. There are signs that a river used to be nearby.
 


### PR DESCRIPTION
The description for Plock contained a smart quote. In KSP, this appears at a square, indicating an invalid character.

The same problem appears in three science descriptions for Slate.

This commit replaces the smart quote character with a traditional single quote character.