### PR TITLE
Improve CustomAsteroids integration

### DIFF
--- a/GameData/OPM/OPM_CustomAsteroids.cfg
+++ b/GameData/OPM/OPM_CustomAsteroids.cfg
@@ -25,6 +25,12 @@ AsteroidSets
 		{
 			avg = 90
 		}
+
+		asteroidTypes
+		{
+			key = 0.2 CaAsteroidIcy
+			key = 0.8 CaAsteroidCarbon
+		}
 	}
 	ASTEROIDGROUP
 	{
@@ -38,8 +44,8 @@ AsteroidSets
 		orbitSize
 		{
 			type = SemimajorAxis
-			min = Ratio(Sarnus.rad, 1.15)
-			max = Ratio(Sarnus.rad, 1.4)
+			min = Ratio(Sarnus.rad, 1.25)
+			max = Ratio(Sarnus.rad, 2.25)
 		}
 
 		eccentricity
@@ -50,6 +56,11 @@ AsteroidSets
 		inclination
 		{
 			avg = 0.5
+		}
+
+		asteroidTypes
+		{
+			key = 1 CaAsteroidIcy
 		}
 	}
 	ASTEROIDGROUP
@@ -77,6 +88,12 @@ AsteroidSets
 		{
 			avg = 90
 		}
+
+		asteroidTypes
+		{
+			key = 0.2 CaAsteroidCarbon
+			Key = 0.8 CaAsteroidIcy
+		}
 	}
 	ASTEROIDGROUP
 	{
@@ -90,8 +107,8 @@ AsteroidSets
 		orbitSize
 		{
 			type = SemimajorAxis
-			min = Ratio(Urlum.rad, 2.3)
-			max = Ratio(Urlum.rad, 2.9)
+			min = Ratio(Urlum.rad, 3.55)
+			max = Ratio(Urlum.rad, 4.7)
 		}
 
 		eccentricity
@@ -102,6 +119,12 @@ AsteroidSets
 		inclination
 		{
 			avg = 0.5
+		}
+
+		asteroidTypes
+		{
+			key = 0.05 CaAsteroidCarbon
+			key = 0.95 CaAsteroidIcy
 		}
 	}
 	ASTEROIDGROUP
@@ -129,6 +152,12 @@ AsteroidSets
 		{
 			avg = 90
 		}
+
+		asteroidTypes
+		{
+			key = 0.15 CaAsteroidCarbon
+			key = 0.85 CaAsteroidIcy
+		}
 	}
 	ASTEROIDGROUP
 	{
@@ -155,6 +184,11 @@ AsteroidSets
 		{
 			avg = 90
 		}
+
+		asteroidTypes
+		{
+			key = 0.15 CaAsteroidCarbon
+			key = 0.85 CaAsteroidIcy
 	}
 	ASTEROIDGROUP
 	{
@@ -180,6 +214,12 @@ AsteroidSets
 		inclination
 		{
 			avg = 0.25
+		}
+
+		asteroidTypes
+		{
+			key = 0.1 CaAsteroidCarbon
+			key = 0.9 CaAsteroidIcy
 		}
 	}	
 }

--- a/GameData/OPM/OPM_CustomAsteroidsTweaks.cfg
+++ b/GameData/OPM/OPM_CustomAsteroidsTweaks.cfg
@@ -6,7 +6,7 @@
 	{
 		@orbitSize
 		{
-			@min = Resonance(Neidon, 2:3.1) // slightly higher than a default CA Eelino/Plockino
+			@min = Resonance(Neidon, 2:3)
 			@max = Resonance(Neidon, 1:2)
 		}
 	}

--- a/GameData/OPM/OPM_CustomAsteroidsTweaks.cfg
+++ b/GameData/OPM/OPM_CustomAsteroidsTweaks.cfg
@@ -1,0 +1,29 @@
+// Changes to CA's asteroids to make them fit the OPM system
+
+@AsteroidSets:HAS[#name[CustomAsteroids_outer]]
+{
+	@ASTEROIDGROUP:HAS[#name[kboNonResonant]]
+	{
+		@orbitSize
+		{
+			@min = Resonance(Neidon, 2:3.1) // slightly higher than a default CA Eelino/Plockino
+			@max = Resonance(Neidon, 1:2)
+		}
+	}
+	@ASTEROIDGROUP:HAS[#name[kbo2-3]]
+	{
+		@orbitSize
+		{
+			@min = Resonance(Neidon, 2:3)
+			@max = Resonance(Neidon, 2:3)
+		}
+	}
+	@ASTEROIDGROUP:HAS[#name[outerComets]]
+	{
+		@orbitSize
+		{
+			@min = Ratio(Neidon.apo, 1.0)
+			@max = Ratio(Neidon.apo, 1.6)
+		}
+	}
+}


### PR DESCRIPTION
* Added asteroid classes to the various planet moonlet populations (no more Rocky 'roids!).
* Increased SMA of ring 'roids to actually be within the rings
* Added a patch (I had to spin this off into a separate file as it didn't seem to work when placed with the main CA cfg) to switch the reference body for several of CustomAsteroid's default 'roid populations (assuming they are installed) to Neidon instead of Jool. Now far-out bodies will actually be far out, and the Kuiper Belt won't be between Jool and Sarnus.