### PR TITLE
Remove superfluous commas from OPM.netkan

### DIFF
--- a/CKAN/OPM.netkan
+++ b/CKAN/OPM.netkan
@@ -16,7 +16,7 @@
             "find": "OPM",
             "install_to": "GameData",
             "comment": "This is the main install for OPM"
-        },
+        }
     ],
     "depends": [
         {
@@ -37,7 +37,7 @@
     "recommends": [
         {
             "name": "CustomBarnKit"
-        },
+        }
     ],
     "suggests": [
         {
@@ -57,9 +57,9 @@
         },
 		{
             "name": "ResearchBodies"
-        },
+        }
     ],
-	"tags": [
+    "tags": [
 		"planet-pack"
-    ],
+    ]
 }


### PR DESCRIPTION
## Motivation
There are superfluous commas in the OPM.netkan, that are invalid json when parsing strict.
CKAN's download counts gathering bot skips this mods out of this reason:
`Failed decoding count for OuterPlanetsMod: Expecting value: line 20 column 5 (char 734)`

## Changes
Remove all unneeded, wrong set commas.
After that (and some time), a download count should be visible in the CKAN client:
![grafik](https://user-images.githubusercontent.com/28812678/67708855-2f58e180-f9bd-11e9-9a18-31a4c7d2b26a.png)
