### PR TITLE
Remove another additional comma from OPM.netkan

### DIFF
--- a/CKAN/OPM.netkan
+++ b/CKAN/OPM.netkan
@@ -43,20 +43,20 @@
         {
             "name": "BetterTimeWarpCont"
         },
-		{
+        {
             "name": "CommunityResourcePack"
         },
-		{
+        {
             "name": "DistantObject"
         },
-		{
+        {
             "name": "FinalFrontier"
         },
-		{
+        {
             "name": "PlanetShine"
-        },
+        }
     ],
     "tags": [
-		"planet-pack"
+        "planet-pack"
     ]
 }


### PR DESCRIPTION
Commit 376acf416507a1f591abe9ace1f0b631ba2f8870 removed one mod from the suggestions list, but didn't remove the trailing comma in the line above, which is considered invalid JSON.

The indentations have also been a mix of tabs and spaces, I converted them all to spaces for consistency.

Pinging @Poodmund in case you've PR notifications disabled.